### PR TITLE
3dtv botenable improved

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1315,7 +1315,6 @@ void GMainWindow::SyncMenuUISettings() {
     ui.action_Screen_Layout_Side_by_Side->setCheckable(!Settings::values.toggle_3d);
     ui.action_Screen_Layout_Stereoscopic->setCheckable(Settings::values.toggle_3d);
     ui.action_Screen_Layout_StereoscopicSingleScreen->setCheckable(Settings::values.toggle_3d);
-    ui.action_Screen_Layout_Swap_Screens->setCheckable(true);
 
     ui.action_Screen_Layout_Default->setChecked(Settings::values.layout_option ==
                                                 Settings::LayoutOption::Default);

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1315,7 +1315,7 @@ void GMainWindow::SyncMenuUISettings() {
     ui.action_Screen_Layout_Side_by_Side->setCheckable(!Settings::values.toggle_3d);
     ui.action_Screen_Layout_Stereoscopic->setCheckable(Settings::values.toggle_3d);
     ui.action_Screen_Layout_StereoscopicSingleScreen->setCheckable(Settings::values.toggle_3d);
-    ui.action_Screen_Layout_Swap_Screens->setCheckable(!Settings::values.toggle_3d);
+    ui.action_Screen_Layout_Swap_Screens->setCheckable(true);
 
     ui.action_Screen_Layout_Default->setChecked(Settings::values.layout_option ==
                                                 Settings::LayoutOption::Default);

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -123,10 +123,10 @@ void EmuWindow::UpdateCurrentFramebufferLayout(unsigned width, unsigned height) 
             layout = Layout::SideFrameLayout(width, height, Settings::values.swap_screen);
             break;
         case Settings::LayoutOption::Stereoscopic:
-            layout = Layout::StereoscopicLayout(width, height);
+            layout = Layout::StereoscopicLayout(width, height, Settings::values.swap_screen);
             break;
         case Settings::LayoutOption::StereoscopicSingleScreen:
-            layout = Layout::StereoscopicSingleScreenLayout(width, height);
+            layout = Layout::StereoscopicSingleScreenLayout(width, height, Settings::values.swap_screen);
             break;
         case Settings::LayoutOption::Default:
         default:

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -126,7 +126,8 @@ void EmuWindow::UpdateCurrentFramebufferLayout(unsigned width, unsigned height) 
             layout = Layout::StereoscopicLayout(width, height, Settings::values.swap_screen);
             break;
         case Settings::LayoutOption::StereoscopicSingleScreen:
-            layout = Layout::StereoscopicSingleScreenLayout(width, height, Settings::values.swap_screen);
+            layout =
+                Layout::StereoscopicSingleScreenLayout(width, height, Settings::values.swap_screen);
             break;
         case Settings::LayoutOption::Default:
         default:

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -192,21 +192,17 @@ FramebufferLayout StereoscopicLayout(unsigned width, unsigned height, bool swapp
 
     float window_aspect_ratio = static_cast<float>(height) / width;
 
-    const float emulation_aspect_ratio =
-        static_cast<float>(Core::kScreenTopHeight + Core::kScreenBottomHeight) /
-        (Core::kScreenTopWidth * 2);
-
     // Apply borders to the left and right sides of each window if needed.
     top_screen = top_screen.TranslateX((screen_window_area.GetWidth() - top_screen.GetWidth()) / 2);
     bot_screen = bot_screen.TranslateX((screen_window_area.GetWidth() - bot_screen.GetWidth()) / 2);
 
     // Apply borders to the top and bottom of both windows together if needed.
-    if (!swapped) {
-        top_screen =
-            top_screen.TranslateY((screen_window_area.GetHeight() - top_screen.GetHeight()));
-    } else {
+    if (swapped) {
         bot_screen =
             bot_screen.TranslateY((screen_window_area.GetHeight() - bot_screen.GetHeight()));
+    } else {
+        top_screen =
+            top_screen.TranslateY((screen_window_area.GetHeight() - top_screen.GetHeight()));
     }
 
     // Move the top screen to the bottom if we are swapped.
@@ -219,15 +215,9 @@ FramebufferLayout StereoscopicSingleScreenLayout(unsigned width, unsigned height
     ASSERT(width > 0);
     ASSERT(height > 0);
 
+    float emulation_aspect_ratio = swapped ? BOT_SCREEN_ASPECT_RATIO : TOP_SCREEN_ASPECT_RATIO;
     // Multiply by two to Halve Screen Width, account for 3DTV stretching
-    float finalAspectRatio = !swapped ? TOP_SCREEN_ASPECT_RATIO * 2 : BOT_SCREEN_ASPECT_RATIO * 2;
-
-    const float emulation_aspect_ratio_top =
-        static_cast<float>(Core::kScreenTopHeight) / (Core::kScreenTopWidth);
-    const float emulation_aspect_ratio_bot =
-        static_cast<float>(Core::kScreenBottomHeight) / (Core::kScreenBottomWidth);
-    const float emulation_aspect_ratio =
-        !swapped ? emulation_aspect_ratio_top : emulation_aspect_ratio_bot;
+    float finalAspectRatio = emulation_aspect_ratio * 2;
 
     float window_aspect_ratio = static_cast<float>(height) / width;
     MathUtil::Rectangle<unsigned> screen_window_area{0, 0, width, height};
@@ -249,10 +239,10 @@ FramebufferLayout StereoscopicSingleScreenLayout(unsigned width, unsigned height
     }
 
     FramebufferLayout res{width, height, !swapped, swapped, {}, {}};
-    if (!swapped) {
-        res.top_screen = screen;
-    } else {
+    if (swapped) {
         res.bottom_screen = screen;
+    } else {
+        res.top_screen = screen;
     }
     return res;
 }

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -182,9 +182,9 @@ FramebufferLayout StereoscopicLayout(unsigned width, unsigned height, bool swapp
     float finalAspectRatioTop = TOP_SCREEN_ASPECT_RATIO * 2;
     float finalAspectRatioBot = BOT_SCREEN_ASPECT_RATIO * 2;
 
-    FramebufferLayout res{ width, height, true, true,{},{} };
+    FramebufferLayout res{width, height, true, true, {}, {}};
     // Default layout gives equal screen sizes to the top and bottom screen
-    MathUtil::Rectangle<unsigned> screen_window_area{ 0, 0, width / 2, height / 2 };
+    MathUtil::Rectangle<unsigned> screen_window_area{0, 0, width / 2, height / 2};
     MathUtil::Rectangle<unsigned> top_screen =
         maxRectangle(screen_window_area, finalAspectRatioTop);
     MathUtil::Rectangle<unsigned> bot_screen =
@@ -196,22 +196,22 @@ FramebufferLayout StereoscopicLayout(unsigned width, unsigned height, bool swapp
         static_cast<float>(Core::kScreenTopHeight + Core::kScreenBottomHeight) /
         (Core::kScreenTopWidth * 2);
 
-    // Apply borders to the left and right sides of each window if needed. (center top and bottom windows independently)
+    // Apply borders to the left and right sides of each window if needed.
     top_screen = top_screen.TranslateX((screen_window_area.GetWidth() - top_screen.GetWidth()) / 2);
     bot_screen = bot_screen.TranslateX((screen_window_area.GetWidth() - bot_screen.GetWidth()) / 2);
 
-    // Apply borders to the top and bottom of both windows together if needed. (center top and bottom windows joined together)
+    // Apply borders to the top and bottom of both windows together if needed.
     if (!swapped) {
-        top_screen = top_screen.TranslateY((screen_window_area.GetHeight() - top_screen.GetHeight()));
-    }
-    else {
-        bot_screen = bot_screen.TranslateY((screen_window_area.GetHeight() - bot_screen.GetHeight()));
+        top_screen =
+            top_screen.TranslateY((screen_window_area.GetHeight() - top_screen.GetHeight()));
+    } else {
+        bot_screen =
+            bot_screen.TranslateY((screen_window_area.GetHeight() - bot_screen.GetHeight()));
     }
 
     // Move the top screen to the bottom if we are swapped.
     res.top_screen = swapped ? top_screen.TranslateY(height / 2) : top_screen;
     res.bottom_screen = swapped ? bot_screen : bot_screen.TranslateY(height / 2);
-
     return res;
 }
 
@@ -222,14 +222,18 @@ FramebufferLayout StereoscopicSingleScreenLayout(unsigned width, unsigned height
     // Multiply by two to Halve Screen Width, account for 3DTV stretching
     float finalAspectRatio = !swapped ? TOP_SCREEN_ASPECT_RATIO * 2 : BOT_SCREEN_ASPECT_RATIO * 2;
 
-    const float emulation_aspect_ratio_top = static_cast<float>(Core::kScreenTopHeight) / (Core::kScreenTopWidth);
-    const float emulation_aspect_ratio_bot = static_cast<float>(Core::kScreenBottomHeight) / (Core::kScreenBottomWidth);
-    const float emulation_aspect_ratio = !swapped ? emulation_aspect_ratio_top : emulation_aspect_ratio_bot;
+    const float emulation_aspect_ratio_top =
+        static_cast<float>(Core::kScreenTopHeight) / (Core::kScreenTopWidth);
+    const float emulation_aspect_ratio_bot =
+        static_cast<float>(Core::kScreenBottomHeight) / (Core::kScreenBottomWidth);
+    const float emulation_aspect_ratio =
+        !swapped ? emulation_aspect_ratio_top : emulation_aspect_ratio_bot;
 
     float window_aspect_ratio = static_cast<float>(height) / width;
-    MathUtil::Rectangle<unsigned> screen_window_area{ 0, 0, width, height };
+    MathUtil::Rectangle<unsigned> screen_window_area{0, 0, width, height};
     // Find largest Rectangle that can fit in the window size with the given aspect ratio
-    MathUtil::Rectangle<unsigned> screen_rect = maxRectangle(screen_window_area, emulation_aspect_ratio);
+    MathUtil::Rectangle<unsigned> screen_rect =
+        maxRectangle(screen_window_area, emulation_aspect_ratio);
 
     // Find the final size of the halved screen within the screen_rect
     MathUtil::Rectangle<unsigned> screen = maxRectangle(screen_rect, finalAspectRatio);
@@ -238,18 +242,16 @@ FramebufferLayout StereoscopicSingleScreenLayout(unsigned width, unsigned height
         // Apply borders to the left and right sides of the window.
         u32 shift_horizontal = (screen_window_area.GetWidth() - screen_rect.GetWidth()) / 4;
         screen = screen.TranslateX(shift_horizontal);
-    }
-    else {
+    } else {
         // Window is narrower than the emulation content => apply borders to the top and bottom
         u32 shift_vertical = (screen_window_area.GetHeight() - screen_rect.GetHeight()) / 2;
         screen = screen.TranslateY(shift_vertical);
     }
 
-    FramebufferLayout res{ width, height, !swapped, swapped,{},{} };
+    FramebufferLayout res{width, height, !swapped, swapped, {}, {}};
     if (!swapped) {
         res.top_screen = screen;
-    }
-    else {
+    } else {
         res.bottom_screen = screen;
     }
     return res;

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -70,7 +70,7 @@ FramebufferLayout SideFrameLayout(unsigned width, unsigned height, bool is_swapp
  * @param height Window framebuffer height in pixels
  * @return Newly created FramebufferLayout object with default screen regions initialized
  */
-FramebufferLayout StereoscopicLayout(unsigned width, unsigned height);
+FramebufferLayout StereoscopicLayout(unsigned width, unsigned height, bool is_swapped);
 
 /**
  * Factory method for constructing a Frame compatible with 3D Monitors (Top Screen Only)
@@ -78,7 +78,7 @@ FramebufferLayout StereoscopicLayout(unsigned width, unsigned height);
  * @param height Window framebuffer height in pixels
  * @return Newly created FramebufferLayout object with default screen regions initialized
  */
-FramebufferLayout StereoscopicSingleScreenLayout(unsigned width, unsigned height);
+FramebufferLayout StereoscopicSingleScreenLayout(unsigned width, unsigned height, bool is_swapped);
 
 /**
  * Factory method for constructing a custom FramebufferLayout

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -163,6 +163,9 @@ void RendererOpenGL::SwapBuffers() {
 void RendererOpenGL::LoadFBToScreenInfo(const GPU::Regs::FramebufferConfig& framebuffer,
                                         ScreenInfo& screen_info, bool right_eye) {
 
+    if (framebuffer.address_right1 == 0 || framebuffer.address_right2 == 0)
+        right_eye = false;
+
     const PAddr framebuffer_addr =
         framebuffer.active_fb == 0
             ? (!right_eye ? framebuffer.address_left1 : framebuffer.address_right1)


### PR DESCRIPTION
Nice work with this stereo implementation!  It works really great on my 3D TV with all the games I've tested.

I made a few updates:

1. The null check in renderer_opengl.cpp fixes games like Zelda - Link Between Worlds which would otherwise crash during startup due to a frame missing the right-eye.
2. I implemented the swap screens functionality for the stereo views.  I like to swap back and forth via a controller button rather than displaying both screens simultaneously.
3. The prior window alignment code was not aligning properly for various aspect ratios.  I tested it by manually resizing the emulator window.  While it is unlikely users with 3D TVs will have odd aspect ratios, I figured it would be more consistent to make 3D alignment behave the same way as the existing 2D alignment.